### PR TITLE
Fix a few typos

### DIFF
--- a/PackageInfo.g
+++ b/PackageInfo.g
@@ -97,7 +97,7 @@ AutoDoc := rec(
       or (at your option) any later version.
       """,
     Acknowledgements := """
-      The authours wish to thank all the comments, suggestions and issue reporting from users and developers of &GAP;, both past and future.
+      The authors wish to thank all the comments, suggestions and issue reporting from users and developers of &GAP;, both past and future.
       Both authors were partially supported by CMUP, member of LASI, which is financed by Portuguese national funds through FCT – Fundação para a Ciência e a Tecnologia, I.P., under the project with references UIDB/00144/2020 and UIDP/00144/2020. 
       """,
   ),

--- a/gap/CF_splashfromViz.g
+++ b/gap/CF_splashfromViz.g
@@ -12,7 +12,7 @@ fi;
 # Splash ... 
 # the input is
 # * a record of options (may not be present) and
-# * a string (dot) or a function that applied to the ramaining argument produces a dot string
+# * a string (dot) or a function that applied to the remaining argument produces a dot string
 if not IsBound(CF_VizViewers) then 
   if ARCH_IS_MAC_OS_X( ) then
     BindGlobal("CF_VizViewers", ["xpdf","open","evince", "okular", "gv"]);
@@ -36,7 +36,7 @@ if not IsBound(CF_Splash) then
       arg := tmp;
     fi;
     ##########
-    # there are global warnings concerning the avaiability of software
+    # there are global warnings concerning the availability of software
     # there is no need to put them here
     ###############
     opt := First(arg, k -> IsRecord(k));

--- a/gap/corefreesub.gd
+++ b/gap/corefreesub.gd
@@ -26,7 +26,7 @@ SetInfoLevel( InfoCoreFreeSub, 1 );
 #! However the restriction on transitive actions is more recent and there are fewer studies like <Cite Key="FP20Tor"/>,<Cite Key="FP21Cor"/>,<Cite Key="FP21Hyper"/> and <Cite Key="FP22Loc"/>.
 #!
 #! During C.A. Piedade's PhD thesis, he studied many of these faithful transitive permutation representations of automorphism groups of abstract regular polytopes and hypertopes.
-#! It was also during this period that this author noticed the abcense of functions/methods in GAP to compute core-free subgroups of a group.
+#! It was also during this period that this author noticed the absence of functions/methods in GAP to compute core-free subgroups of a group.
 #! As a consequence, he created many functions to help in his research, resulting in many of the functions and methods implemented in this package.
 #! 
 #! One of the important tools for studying faithful transitive permutation representations is by using <A>faithful transitive permutation representation graphs</A>, which are <A>Schreier coset graphs</A>.
@@ -39,17 +39,17 @@ SetInfoLevel( InfoCoreFreeSub, 1 );
 #!
 #! This package was created using the GAP Package <A>PackageMaker</A> <Cite Key="PackageMaker"/>, with documentation done using <A>AutoDoc</A> <Cite Key="AutoDoc"/>.
 #!
-#! @Section Instalation
+#! @Section Installation
 #! 
-#! To install this package, you can simply copy the folder of &corefreesub; and its contents into your <A>/pkg</A> folder inside your &GAP; instalation folder.
+#! To install this package, you can simply copy the folder of &corefreesub; and its contents into your <F>/pkg</F> folder inside your &GAP; installation folder.
 #! This should work for Windows, Ubuntu and MacOS.
-#! If you are using GAP.app on MacOS, the &corefreesub; folder should be copied into your user Library/Preferences/GAP/pkg folder. 
+#! If you are using GAP.app on MacOS, the &corefreesub; folder should be copied into your user <F>Library/Preferences/GAP/pkg</F> folder.
 #!
 #! This package was tested with &GAP; version greater or equal to 4.11.
 #! 
-#! @Section Testing your instalation
+#! @Section Testing your installation
 #! 
-#! To test your instalation, you can run the function <A>CF_TESTALL()</A>. 
+#! To test your installation, you can run the function <A>CF_TESTALL()</A>. 
 #! This function will run two sets of tests, one dependent on the
 #! documentation of the &corefreesub; package and another with assertions with groups with bigger size.
 #! 
@@ -59,7 +59,7 @@ SetInfoLevel( InfoCoreFreeSub, 1 );
 #! Running list 1 . . .
 #! gap>
 #! @EndLogSession
-#! This tests will also produce two pictures that are supposed to be outputed and open in the user system.
+#! This tests will also produce two pictures that are supposed to be output and open in the user system.
 #! If the tests run with no error but they do not output any of the graphs, then it may mean the user might not be able to
 #! use this functionality. If so, please report an issue on <URL Text="CoreFreeSub GitHub Issues">https://github.com/CAPiedade/corefreesub/issues</URL>.
 #! 
@@ -176,7 +176,7 @@ DeclareOperation( "FaithfulTransitivePermutationRepresentations", [IsGroup]);
 #! @Section Faithful Transitive Permutation Representation of Minimal Degree
 #! 
 #! To complement the already existing functions in GAP <A>MinimalFaithfulPermutationDegree</A> and <A>MinimalFaithfulPermutationRepresentation</A>,
-#! the following functions to retreive the <A>MinimalFaithfulTransitivePermutationRepresentation</A> and <A>MinimalFaithfulTransitivePermutationDegree</A>.
+#! the following functions to retrieve the <A>MinimalFaithfulTransitivePermutationRepresentation</A> and <A>MinimalFaithfulTransitivePermutationDegree</A>.
 #!
 #! @Arguments G [,all_minimal_ftpr]
 #! @Returns an isomorphism (or a list of isomorphisms)
@@ -213,7 +213,7 @@ DeclareGlobalFunction( "MinimalFaithfulTransitivePermutationDegree" );
 
 #! @Section Faithful Transitive Permutation Representation of given Degree
 #! 
-#! To obtain a Faithful Transitive Permutation Representatio of a specific Degree, the following function
+#! To obtain a faithful transitive permutation Representation of a specific degree, the following function
 #! <A>FaithfulTransitivePermutationRepresentationsOfDegree</A> can be used.
 #!
 #! @Arguments G, d [,all_ftpr_of_given_degree]


### PR DESCRIPTION
Also use <F>...</F> to wrap file names and paths, not <A>...</A> which
is intended for *a*rguments.
