### PR TITLE
Remove dependence on SmallGrps 

### DIFF
--- a/tst/OtherTest.tst
+++ b/tst/OtherTest.tst
@@ -17,7 +17,7 @@ gap> d := DirectProduct(SymmetricGroup(5),SymmetricGroup(6));; cfccs := CoreFree
 gap> ccs := Filtered(ConjugacyClassesSubgroups(d), i -> IsCoreFree(d,i[1]));;
 gap> Size(ccs)= Size(cfccs);
 true
-gap> g := SmallGroup(2000,120);; cfccs := CoreFreeConjugacyClassesSubgroupsOfSolvableGroup(g);;
+gap> g := PcGroupCode(105641121221273607348650803, 2000);; cfccs := CoreFreeConjugacyClassesSubgroupsOfSolvableGroup(g);;
 gap> ccs := Filtered(ConjugacyClassesSubgroups(g), i -> IsCoreFree(g,i[1]));;
 gap> Size(ccs)= Size(cfccs);
 true

--- a/tst/testall.g
+++ b/tst/testall.g
@@ -7,7 +7,7 @@
 LoadPackage( "corefreesub" );
 
 TestDirectory(DirectoriesPackageLibrary( "corefreesub", "tst" ),
-  rec(exitGAP := true, rewriteToFile:=true));
+  rec(exitGAP := true, rewriteToFile:=false));
 
 
 


### PR DESCRIPTION
This PR does 2 things: 

1) removes the use of `SmallGroup` in the tests, motivated by https://github.com/gap-system/gap/issues/2434
2) Removes `rewriteToFile := true` from `testall.g`. This option rewrites the file every time `gap tst/testall.g` is invoked, which doesn't seem very sensible (if a test goes wrong, you've already written the wrong output to the file, then next time the test will pass with the wrong output).